### PR TITLE
Fix and run tests on Travis for Python 2.7 & pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - 2.6
+  - 2.7
+  - pypy
+
+install:
+  - python setup.py install
+
+script:
+  - python setup.py nosetests

--- a/nosetrim/nosetrim.py
+++ b/nosetrim/nosetrim.py
@@ -31,10 +31,16 @@ to create a link to the latest version.
 
 import os, logging, sys
 import inspect
-from nose.plugins import Plugin
-from unittest.runner import _WritelnDecorator
-from unittest import TestResult
+
+try:
+    from unittest2.runner import _WritelnDecorator
+    from unittest2 import TestResult
+except ImportError:
+    from unittest.runner import _WritelnDecorator
+    from unittest import TestResult
+
 from nose.result import TextTestResult, ln
+from nose.plugins import Plugin
 
 log = logging.getLogger('nose.plugins.trim')
 

--- a/nosetrim/test.py
+++ b/nosetrim/test.py
@@ -45,7 +45,10 @@ class PluginTester(object):
     env = {}
     _args = None
     nose = None
-    test_program = ['nosetests']
+    if sys.executable and sys.version_info >= (2, 7):
+        test_program = [sys.executable, '-m', 'nose']
+    else:
+        test_program = ['nosetests']
     
     def makeSuite(self):
         """must return the full path to a directory to test."""
@@ -122,8 +125,14 @@ class NoseStream(object):
     def __init__(self, proc, debug=True):
         self.proc = proc
         self.debug = debug
-        self.returncode = None
+        self._returncode = None
         self.buffer = []
+
+    @property
+    def returncode(self):
+        if self._returncode is None:
+            list(iter(self))
+        return self._returncode
     
     def __contains__(self, value):
         for line in self:
@@ -146,20 +155,19 @@ class NoseStream(object):
         output is stdout + stderr unless Popen was configured otherwise
         """
         self._startDebugOut()
-        if self.buffer:
-            for line in self.buffer:
-                self._debugLineOut(line)
-                yield line
-        else:
-            while 1:
-                line = self.proc.stdout.readline()
-                if not line:
-                    break
+
+        for line in self.buffer:
+            self._debugLineOut(line)
+            yield line
+
+        if self._returncode is None:
+            for line in self.proc.stdout:
                 clean_line = line.rstrip()
                 self.buffer.append(clean_line)
                 self._debugLineOut(clean_line)
                 yield clean_line
-            self.returncode = self.proc.wait()
+            self._returncode = self.proc.wait()
+
         self._endDebugOut()
 
 class NoseTrimTest(PluginTester):
@@ -227,4 +235,3 @@ def test_lone_error():
     
     def test_non_dupes(self):
         assert "+ 0 more" not in self.nose
-        

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 
 from setuptools import setup, find_packages
 
+extras_require = {
+    ':python_version=="2.6"': ['unittest2'],
+}
+
 setup(
     name='nosetrim',
     version='0.1',
@@ -11,6 +15,7 @@ setup(
     description = ( 
         "A nose plugin that reports only unique exceptions"),
     install_requires='nose',
+    extras_require=extras_require,
     license = 'GNU LGPL',
     packages = find_packages(),
     keywords = 'test unittest nose nosetests',
@@ -19,5 +24,14 @@ setup(
             'trim = nosetrim:NoseTrim'
             ]
         },
-    )
-
+    tests_require=['fixture'],
+    classifiers=[
+        'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
+        'Development Status :: 4 - Beta',
+        'Operating System :: OS Independent',
+        'Intended Audience :: Developers',
+        'Environment :: Console',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Software Development :: Testing',
+    ],
+)


### PR DESCRIPTION
`NoseStream.__iter__` did not resume processing the stream if the
first iterator did not complete the stream, and .returncode
may not have been set.

Also allow use sys.executable for the subprocess to ensure the correct
Python interpreter is used, allowing test suite invocation like:

```
python2.7 -m nose
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cpennington/nosetrim/1)
<!-- Reviewable:end -->
